### PR TITLE
Update to fix HTTP endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.sonatype.oss</groupId>
@@ -10,16 +10,16 @@
     <version>0.0.4-SNAPSHOT</version>
     <name>quarkee-archetype</name>
     <description>quarkus.io with Java EE-stic out-of-the-box experience</description>
-    <url>http://airhacks.com</url>
+    <url>https://airhacks.com</url>
     <organization>
         <name>Adam Bien</name>
-        <url>http://adam-bien.com</url>
+        <url>https://adam-bien.com</url>
     </organization>
     <inceptionYear>2019</inceptionYear>
     <licenses>
         <license>
             <name>The Apache Software License, Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
             <distribution>repo</distribution>
         </license>
     </licenses>
@@ -27,7 +27,7 @@
         <developer>
             <name>Adam Bien</name>
             <organization>adam-bien.com</organization>
-            <organizationUrl>http://adam-bien.com</organizationUrl>
+            <organizationUrl>https://adam-bien.com</organizationUrl>
         </developer>
     </developers>
     <packaging>maven-archetype</packaging>


### PR DESCRIPTION
Some of the endpoints are still using HTTP that is insecure ... replaced with secure HTTP (HTTP with SSL/TLS) that exists

Details:

I found instances where the HTTP protocol is used instead of HTTPS (HTTP with TLS). According to the Common Weakness Enumeration organization this is a security weakness (https://cwe.mitre.org/data/definitions/319.html).